### PR TITLE
range & struct improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.idea
-.git
+.idea/
+.git/
 target/
-.vscode
+file_tests/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adana"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adana"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 authors = ["Nordine Bittich"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "namespaces aliases for command lines & basic scripting language"
 homepage = "https://github.com/nbittich/adana"
 readme = "README.md"
-exclude = ["vscode/","dist/", ".vscode", ".history" ]
+exclude = ["vscode/","dist/", ".vscode", ".history", ".git", ".github"]
 
 [dependencies]
 anyhow = "1.0.69"
@@ -19,7 +19,7 @@ nu-ansi-term = "0.46.0"
 rustyline = "10.1.1"
 rustyline-derive = "0.7.0"
 serde = {version = "1.0.152", features= ['serde_derive', 'rc']}
-serde_json = "1.0.92"
+serde_json = "1.0.93"
 slab_tree = "0.3.2"
 strum = { version = "0.24.1", features = ["derive"] }
 ctrlc = "3.2.5"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Scripting programming language, repl and namespaced aliases for commands.
     * [Operators and constants](#operators-and-constants)
     * [Variable definition](#variable-definition)
     * [Loops](#loops)
+    * [Ranges](#ranges)
     * [Conditions](#conditions)
     * [Types](#types)
     * [Structs](#structs)
@@ -210,9 +211,9 @@ In the case of a struct, the variable will be an entry (a struct with key/value)
 
 ```javascript
         s = struct {
-            name: "nordine";
-            age: 34;
-            members: ["natalie", "roger","fred"];
+            name: "nordine",
+            age: 34,
+            members: ["natalie", "roger","fred"]
         }
         for  id, entry in s {
              println("Id: "+id +" Key: "+entry.key + " Value: " + to_string(entry.value))
@@ -243,6 +244,22 @@ while(count < 10) {
         break
      }
    }
+```
+
+<hr>
+
+### Ranges
+
+It is possible to define a range (inclusive, exclusive):
+
+```javascript
+
+x = 1..11 # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+for i in 1..11 {
+  println("print 10 times this message")
+}
+
 ```
 
 <hr>
@@ -280,7 +297,7 @@ Below, is a list of types and how you declare them. You can also define your str
 | string   | `"hello"`                                                                                         |
 | array    | `[1,2,"3", true]`                                                                                 |
 | function | `() => {"hello"}` <br> `(name) => {"hello" + name}` <br> `(n) => {`<br>&emsp;  `"hello"`<br>`  }` |
-| struct   | `struct {x: 8; y: ()=> {println("hello!")};}`
+| struct   | `struct {x: 8, y: ()=> {println("hello!")}}`
 <hr>
 
 ### Structs
@@ -289,32 +306,32 @@ You can define structs. Structs are a way of grouping related variables or funct
 You can define function variables within a struct, but you cannot update the members of the function from within
 the struct (there is no `self` or `this`).
 
-The semicolon is required to separate each member, even the latest one.
+The comma is required to separate each member, but not for the latest one.
 
 Example of defining a struct:
 
 ```javascript
 person = struct {
-    name: "hello";
-    age: 20;
+    name: "hello",
+    age: 20
 }
 
 person_service = struct {
-    say_hi: (person) => { println("hi " + person.name) };
+    say_hi: (person) => { println("hi " + person.name) },
     check_age: (person) => {
              if (person.age < 18) {
                  println("you are too young")
              } else {
                  println("you are too old")
              }
-    };
+    }
 }
 
 person_service.check_age(person)
 
 ```
 
-You can access a struct in two ways:
+You can access a struct in two ways, except for the functions members:
 
 ```javascript
 name = person["name"] # name contains "hello"

--- a/src/adana_script/ast.rs
+++ b/src/adana_script/ast.rs
@@ -193,6 +193,53 @@ pub(super) fn to_ast(
             tree,
             curr_node_id,
         ),
+        Value::Range { incl, excl } => {
+            let incl = match *incl {
+                Value::Variable(name) => {
+                    let primitive =
+                        variable_from_ctx(name.as_str(), false, ctx)?;
+                    if let Primitive::Int(num) = primitive {
+                        Ok(num)
+                    } else {
+                        Err(anyhow::format_err!(
+                            "range error: {primitive:?} is not an integer"
+                        ))
+                    }
+                }
+                Value::Integer(num) => Ok(num),
+                _ => {
+                    return Err(anyhow::format_err!(
+                        "range error: {incl:?} is not an integer"
+                    ))
+                }
+            }?;
+            let excl = match *excl {
+                Value::Variable(name) => {
+                    let primitive =
+                        variable_from_ctx(name.as_str(), false, ctx)?;
+                    if let Primitive::Int(num) = primitive {
+                        Ok(num)
+                    } else {
+                        Err(anyhow::format_err!(
+                            "range error: {primitive:?} is not an integer"
+                        ))
+                    }
+                }
+                Value::Integer(num) => Ok(num),
+                _ => {
+                    return Err(anyhow::format_err!(
+                        "range error: {excl:?} is not an integer"
+                    ))
+                }
+            }?;
+            let range: Vec<Primitive> =
+                (incl..excl).map(Primitive::Int).collect();
+            append_to_current_and_return(
+                TreeNodeValue::Primitive(Primitive::Array(range)),
+                tree,
+                curr_node_id,
+            )
+        }
         Value::Variable(name) => {
             let value = variable_from_ctx(name.as_str(), false, ctx)?;
             append_to_current_and_return(

--- a/src/adana_script/compute.rs
+++ b/src/adana_script/compute.rs
@@ -663,6 +663,7 @@ pub fn compute(
         dbg!(rest);
         dbg!(&instructions);
     }
+
     anyhow::ensure!(
         rest.trim().is_empty(),
         format!("Invalid operation! {instructions:?} => {rest}")

--- a/src/adana_script/mod.rs
+++ b/src/adana_script/mod.rs
@@ -5,7 +5,6 @@ mod primitive;
 
 use std::collections::BTreeMap;
 
-
 pub use compute::compute;
 pub use primitive::MutPrimitive;
 pub use primitive::Primitive;

--- a/src/adana_script/mod.rs
+++ b/src/adana_script/mod.rs
@@ -119,6 +119,10 @@ pub enum Value {
     Decimal(f64),
     Integer(i128),
     Bool(bool),
+    Range {
+        incl: Box<Value>,
+        excl: Box<Value>,
+    },
     String(String),
     BlockParen(Vec<Value>),
     Variable(String),

--- a/src/adana_script/mod.rs
+++ b/src/adana_script/mod.rs
@@ -4,7 +4,7 @@ mod parser;
 mod primitive;
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
+
 
 pub use compute::compute;
 pub use primitive::MutPrimitive;

--- a/src/adana_script/mod.rs
+++ b/src/adana_script/mod.rs
@@ -3,6 +3,7 @@ mod compute;
 mod parser;
 mod primitive;
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 pub use compute::compute;
@@ -152,7 +153,7 @@ pub enum Value {
         arr: Box<Value>,
         index: Box<Value>,
     },
-    Struct(HashMap<String, Value>),
+    Struct(BTreeMap<String, Value>),
     StructAccess {
         struc: Box<Value>,
         key: String,
@@ -212,7 +213,7 @@ pub(super) enum TreeNodeValue {
     IfExpr(Value),
     WhileExpr(Value),
     Array(Vec<Value>),
-    Struct(HashMap<String, Value>),
+    Struct(BTreeMap<String, Value>),
     StructAccess { struc: Value, key: Primitive },
     ArrayAccess { index: Primitive, array: Value },
     Function(Value),

--- a/src/adana_script/parser.rs
+++ b/src/adana_script/parser.rs
@@ -1,5 +1,3 @@
-
-
 use crate::{
     prelude::{
         all_consuming, alt, delimited, double, many0, many1, map, map_parser,

--- a/src/adana_script/parser.rs
+++ b/src/adana_script/parser.rs
@@ -1,4 +1,4 @@
-use nom::combinator::{cut, eof};
+
 
 use crate::{
     prelude::{

--- a/src/adana_script/parser.rs
+++ b/src/adana_script/parser.rs
@@ -43,12 +43,17 @@ fn parse_number(s: &str) -> Res<Value> {
 
 fn parse_range(s: &str) -> Res<Value> {
     map(
-        separated_pair(
-            map_parser(
-                take_until(".."),
-                preceded(multispace0, alt((parse_variable, parse_number))),
+        pair(
+            preceded(
+                multispace0,
+                terminated(
+                    map_parser(
+                        take_until(".."),
+                        all_consuming(alt((parse_variable, parse_number))),
+                    ),
+                    tag_no_space(".."),
+                ),
             ),
-            tag(".."),
             alt((parse_variable, parse_number)),
         ),
         |(incl, excl)| Value::Range {
@@ -368,9 +373,9 @@ fn parse_value(s: &str) -> Res<Value> {
                 parse_struct_access,
                 parse_array_access,
                 parse_array,
+                parse_range,
                 parse_fn,
                 parse_block_paren,
-                parse_range,
                 parse_builtin_fn,
                 parse_operation,
                 parse_string,

--- a/src/adana_script/tests/foreach.rs
+++ b/src/adana_script/tests/foreach.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap};
+use std::collections::BTreeMap;
 
 use crate::adana_script::{compute, Primitive};
 
@@ -270,7 +270,7 @@ fn simple_foreach_with_idx_from_fn() {
 fn simple_foreach_with_idx_from_struct() {
     let expr = r#"
          struc = struct {
-             arr: [1, 2, 3, 4];
+             arr: [1, 2, 3, 4]
          }
          total = 0
          idx_total = 0
@@ -323,7 +323,7 @@ fn simple_foreach_with_idx_with_paren() {
 fn simple_foreach_with_idx_from_struct_with_paren() {
     let expr = r#"
          struc = struct {
-             arr: [1, 2, 3, 4];
+             arr: [1, 2, 3, 4],
          }
          total = 0
          idx_total = 0
@@ -358,9 +358,9 @@ fn test_foreach_struct() {
     let expr = r#"
         result = [] 
         s = struct {
-            name: "nordine";
-            age: 34;
-            members: ["natalie", "roger","fred"];
+            name: "nordine",
+            age: 34,
+            members: ["natalie", "roger","fred"]
         }
         for  id, entry in s {
             result = result + ("Id: "+id +" Key: "+entry.key + " Value: " +to_string(entry.value))

--- a/src/adana_script/tests/mod.rs
+++ b/src/adana_script/tests/mod.rs
@@ -2,6 +2,7 @@ mod builtin;
 mod foreach;
 mod funct;
 mod misc;
+mod range;
 mod struc;
 mod test_array;
 mod test_parser;

--- a/src/adana_script/tests/range.rs
+++ b/src/adana_script/tests/range.rs
@@ -35,6 +35,49 @@ fn simple_range() {
     assert!(ctx.get("a").is_none());
 }
 #[test]
+fn simple_range_in_array() {
+    let expr = r#"
+            arr = [ 9, 1, 3, true, 1..5 ]
+         "#;
+    let mut ctx = BTreeMap::new();
+    let _ = compute(expr, &mut ctx).unwrap();
+    assert_eq!(
+        Primitive::Array(vec![
+            Primitive::Int(9),
+            Primitive::Int(1),
+            Primitive::Int(3),
+            Primitive::Bool(true),
+            Primitive::Array(vec![
+                Primitive::Int(1),
+                Primitive::Int(2),
+                Primitive::Int(3),
+                Primitive::Int(4),
+            ])
+        ]),
+        ctx["arr"].read().unwrap().clone()
+    );
+    assert!(ctx.get("a").is_none());
+}
+#[test]
+fn simple_range_in_function() {
+    let expr = r#"
+            x = () => {1..5}
+            arr = x()
+         "#;
+    let mut ctx = BTreeMap::new();
+    let _ = compute(expr, &mut ctx).unwrap();
+    assert_eq!(
+        Primitive::Array(vec![
+            Primitive::Int(1),
+            Primitive::Int(2),
+            Primitive::Int(3),
+            Primitive::Int(4),
+        ]),
+        ctx["arr"].read().unwrap().clone()
+    );
+    assert!(ctx.get("a").is_none());
+}
+#[test]
 fn simple_range_struct() {
     let expr = r#"
             s = struct {

--- a/src/adana_script/tests/range.rs
+++ b/src/adana_script/tests/range.rs
@@ -38,8 +38,8 @@ fn simple_range() {
 fn simple_range_struct() {
     let expr = r#"
             s = struct {
-                x: 2; #end
-                a: [1,2,3,4]; #end
+                x: 2, #end
+                a: [1,2,3,4]#end
             }#end
          "#;
     let mut ctx = BTreeMap::new();

--- a/src/adana_script/tests/range.rs
+++ b/src/adana_script/tests/range.rs
@@ -1,0 +1,62 @@
+use std::collections::BTreeMap;
+
+use crate::adana_script::{compute, Primitive};
+
+#[test]
+fn simple_foreach_range() {
+    let expr = r#"
+         arr = [1,2,3,4]
+         total = 0
+         for a in 0..4 {
+             total = total + arr[a]
+         }
+       "#;
+    let mut ctx = BTreeMap::new();
+    let _ = compute(expr, &mut ctx).unwrap();
+    assert_eq!(Primitive::Int(10), ctx["total"].read().unwrap().clone());
+    assert!(ctx.get("a").is_none());
+}
+#[test]
+fn simple_range() {
+    let expr = r#"
+            arr = 1..5
+         "#;
+    let mut ctx = BTreeMap::new();
+    let _ = compute(expr, &mut ctx).unwrap();
+    assert_eq!(
+        Primitive::Array(vec![
+            Primitive::Int(1),
+            Primitive::Int(2),
+            Primitive::Int(3),
+            Primitive::Int(4),
+        ]),
+        ctx["arr"].read().unwrap().clone()
+    );
+    assert!(ctx.get("a").is_none());
+}
+#[test]
+fn simple_range_struct() {
+    let expr = r#"
+            s = struct {
+                x: 2; #end
+                a: [1,2,3,4]; #end
+            }#end
+         "#;
+    let mut ctx = BTreeMap::new();
+    let _ = compute(expr, &mut ctx).unwrap();
+    assert_eq!(
+        Primitive::Struct(BTreeMap::from([
+            (
+                "a".to_string(),
+                Primitive::Array(vec![
+                    Primitive::Int(1),
+                    Primitive::Int(2),
+                    Primitive::Int(3),
+                    Primitive::Int(4),
+                ])
+            ),
+            ("x".to_string(), Primitive::Int(2)),
+        ])),
+        ctx["s"].read().unwrap().clone()
+    );
+}

--- a/src/adana_script/tests/struc.rs
+++ b/src/adana_script/tests/struc.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap};
+use std::collections::BTreeMap;
 
 use serial_test::serial;
 
@@ -8,7 +8,7 @@ use crate::adana_script::{compute, Primitive, Value};
 #[serial]
 fn test_simple_struc() {
     let mut ctx = BTreeMap::new();
-    let expr = "x = struct {x: 8;}";
+    let expr = "x = struct {x: 8}";
     let _ = compute(expr, &mut ctx).unwrap();
     assert_eq!(ctx.len(), 1);
     assert_eq!(
@@ -25,9 +25,9 @@ fn test_simple_struc() {
 fn test_simple_struc_with_more_stuff_in_it() {
     let mut ctx = BTreeMap::new();
     let expr = r#"x = struct {
-                x: 8;
-                y: "hello;";
-                z: ()=> {println("hello")};
+                x: 8,
+                y: "hello;",
+                z: ()=> {println("hello")}
            }"#;
     let _ = compute(expr, &mut ctx).unwrap();
     assert_eq!(ctx.len(), 1);
@@ -61,14 +61,14 @@ fn test_struct_eq() {
     let mut ctx = BTreeMap::new();
     let expr = r#"
         x = struct {
-                x: 8;
-                y: "hello;";
-                z: ()=> {println("hello")};
+                x: 8,
+                y: "hello;",
+                z: ()=> {println("hello")},
             }
         y = struct {
-          z: () => {println("hello")};
-          x: 8;
-          y: "hello;";
+          z: () => {println("hello")},
+          x: 8,
+          y: "hello;"
         }
         x == y
     "#;
@@ -77,13 +77,13 @@ fn test_struct_eq() {
 
     let expr = r#"
         x = struct {
-                x: 8;
-                y: "hello;";
-                z: ()=> {println("hello")};
+                x: 8,
+                y: "hello;",
+                z: ()=> {println("hello")}
             }
         y = struct {
-          z: () => {println("hello")};
-          x: 8;
+          z: () => {println("hello")},
+          x: 8
         }
         x == y
     "#;
@@ -97,8 +97,8 @@ fn test_struct_access() {
     let mut ctx = BTreeMap::new();
     let expr = r#"
         person = struct {
-                    name: "hello";
-                    age: 20;
+                    name: "hello",
+                    age: 20,
                  }
         person.age
         "#;
@@ -112,8 +112,8 @@ fn test_struct_variable_assign() {
     let mut ctx = BTreeMap::new();
     let expr = r#"
         person = struct {
-                    name: "hello";
-                    age: 20;
+                    name: "hello",
+                    age: 20,
                  }
         person.age = 34
         person.age
@@ -127,27 +127,27 @@ fn test_struct_complex_ish() {
     let mut ctx = BTreeMap::new();
     let expr = r#"
         person = struct {
-                    name: "hello";
-                    age: 14;
-                    full_name: null;
+                    name: "hello",
+                    age: 14,
+                    full_name: null,
                  }
         # person.age
 
         person_service = struct {
-            say_hi:    (person) => { "hi " + person.name };
+            say_hi:    (person) => { "hi " + person.name },
             check_age: (person) => {
                 if (person.age < 18) {
                   return "you are too young"
                 } else {
                   return "you are too old"
              }
-            };
+            },
             boom: (person) => {
                 if(person.full_name ==null) {
                     return "John Doe"
                 }
                 person.full_name
-            };
+            },
         }
         test1 = person_service.say_hi(person)
         test2 = person_service.check_age(person)
@@ -185,9 +185,9 @@ fn test_struct_access_key() {
     let mut ctx = BTreeMap::new();
     let expr = r#"
         s = struct {
-            name: "nordine";
-            age: 34;
-            members: ["natalie", "roger","fred"];
+            name: "nordine",
+            age: 34,
+            members: ["natalie", "roger","fred"],
         }
         s["name"]
 

--- a/src/adana_script/tests/test_parser.rs
+++ b/src/adana_script/tests/test_parser.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap};
 
 use crate::adana_script::{
     parser::parse_instructions,

--- a/src/adana_script/tests/test_parser.rs
+++ b/src/adana_script/tests/test_parser.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap};
+use std::collections::BTreeMap;
 
 use crate::adana_script::{
     parser::parse_instructions,

--- a/src/adana_script/tests/test_parser.rs
+++ b/src/adana_script/tests/test_parser.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::adana_script::{
     parser::parse_instructions,
@@ -241,17 +241,17 @@ fn test_paren_bug_2023() {
 }
 #[test]
 fn test_struct1() {
-    let expr = " struct {x: 99;}";
+    let expr = " struct {x: 99,}";
     let (res, struc) = parse_instructions(expr).unwrap();
     assert_eq!("", res);
     assert_eq!(
-        vec![Value::Struct(HashMap::from([("x".into(), Value::Integer(99))]))],
+        vec![Value::Struct(BTreeMap::from([("x".into(), Value::Integer(99))]))],
         struc
     );
 }
 #[test]
 fn test_struct_array() {
-    let expr = r#"x = [1, 2, struct{x: (name)=> {println("hello" + name)};}, "hello"]"#;
+    let expr = r#"x = [1, 2, struct{x: (name)=> {println("hello" + name)},}, "hello"]"#;
     let (res, struc_arr) = parse_instructions(expr).unwrap();
     assert_eq!("", res);
     assert_eq!(
@@ -261,7 +261,7 @@ fn test_struct_array() {
             expr: Box::new(Value::Array(vec![
                 Value::Integer(1,),
                 Value::Integer(2,),
-                Value::Struct(HashMap::from([(
+                Value::Struct(BTreeMap::from([(
                     "x".to_string(),
                     Value::Function {
                         parameters: Box::new(Value::BlockParen(vec![
@@ -287,7 +287,7 @@ fn test_struct_array() {
 #[test]
 fn test_struct_array2() {
     let expr = r#"x = [1, 2, struct{
-                                x: (name)=> {println("hello" + name)};
+                                x: (name)=> {println("hello" + name)},
                             },
                "hello"]"#;
     let (res, struc_arr) = parse_instructions(expr).unwrap();
@@ -299,7 +299,7 @@ fn test_struct_array2() {
             expr: Box::new(Value::Array(vec![
                 Value::Integer(1,),
                 Value::Integer(2,),
-                Value::Struct(HashMap::from([(
+                Value::Struct(BTreeMap::from([(
                     "x".to_string(),
                     Value::Function {
                         parameters: Box::new(Value::BlockParen(vec![
@@ -328,23 +328,24 @@ fn test_struct2() {
         # commentaire
       my = struct { # commentaire
           # ici un commentaire
-            b : "salut"; # i am a comment
-            c : [1,2,3];
-            a : 7;
-      # autre : ["commentaire"];
-            d : 1.;
-            x : true;
-            g : null;
+            b : "salut", # i am a comment
+            c : [1,2,3],
+            a : 7,
+      # autre : ["commentaire"],
+            d : 1.,
+            x : true,
+            g : null,
             aa : (n) => {
                 print("hello" + n)
-            }; # commentaire
+            }, # commentaire
             i : ()=> {
                 1
-            };
-            j : 4*2+1 *sqrt(2.);
-            r : () => {"hello!"};
-            mm : (2 *2);
+            },
+            j : 4*2+1 *sqrt(2.),
+            r : () => {"hello!"},
+            mm : (2 *2),
         }
+        #parse_number,
         "#;
     let (res, struc) = parse_instructions(expr).unwrap();
     dbg!(&struc);
@@ -354,7 +355,8 @@ fn test_struct2() {
         struc,
         vec![Value::VariableExpr {
             name: Box::new(Value::Variable("my".to_string(),)),
-            expr: Box::new(Value::Struct(HashMap::from([
+            expr: Box::new(Value::Struct(BTreeMap::from([
+                ("a".into(), Value::Integer(7,)),
                 (
                     "aa".into(),
                     Value::Function {
@@ -373,16 +375,7 @@ fn test_struct2() {
                         ],),],
                     }
                 ),
-                ("a".into(), Value::Integer(7,)),
-                (
-                    "r".into(),
-                    Value::Function {
-                        parameters: Box::new(BlockParen(vec![],)),
-                        exprs: vec![Value::BlockParen(vec![Value::String(
-                            "hello!".into(),
-                        ),],),],
-                    }
-                ),
+                ("b".into(), Value::String("salut".into(),)),
                 (
                     "c".into(),
                     Value::Array(vec![
@@ -391,6 +384,8 @@ fn test_struct2() {
                         Value::Integer(3,),
                     ],)
                 ),
+                ("d".into(), Value::Decimal(1.0,)),
+                ("g".into(), Value::Null),
                 (
                     "i".into(),
                     Value::Function {
@@ -399,15 +394,6 @@ fn test_struct2() {
                             Value::Integer(1,),
                         ],),],
                     }
-                ),
-                ("x".into(), Value::Bool(true,)),
-                (
-                    "mm".into(),
-                    Value::BlockParen(vec![
-                        Value::Integer(2,),
-                        Value::Operation(Operator::Mult,),
-                        Value::Integer(2,),
-                    ],)
                 ),
                 (
                     "j".into(),
@@ -426,9 +412,24 @@ fn test_struct2() {
                         },
                     ]),
                 ),
-                ("b".into(), Value::String("salut".into(),)),
-                ("d".into(), Value::Decimal(1.0,)),
-                ("g".into(), Value::Null),
+                (
+                    "mm".into(),
+                    Value::BlockParen(vec![
+                        Value::Integer(2,),
+                        Value::Operation(Operator::Mult,),
+                        Value::Integer(2,),
+                    ],)
+                ),
+                (
+                    "r".into(),
+                    Value::Function {
+                        parameters: Box::new(BlockParen(vec![],)),
+                        exprs: vec![Value::BlockParen(vec![Value::String(
+                            "hello!".into(),
+                        ),],),],
+                    }
+                ),
+                ("x".into(), Value::Bool(true,)),
             ]),)),
         }]
     );
@@ -593,8 +594,8 @@ fn test_comments_end_arr() {
 fn test_struct_access_1() {
     let expr = r#"
             person = struct {
-                name: "nordine";
-                age: 34;
+                name: "nordine",
+                age: 34,
             }
             println(person.age)
             x = [9, person.name]
@@ -606,7 +607,7 @@ fn test_struct_access_1() {
         vec![
             Value::VariableExpr {
                 name: Box::new(Value::Variable("person".to_string(),)),
-                expr: Box::new(Value::Struct(HashMap::from([
+                expr: Box::new(Value::Struct(BTreeMap::from([
                     ("name".to_string(), Value::String("nordine".to_string(),)),
                     ("age".to_string(), Value::Integer(34,),)
                 ]),)),

--- a/src/adana_script/tests/test_parser.rs
+++ b/src/adana_script/tests/test_parser.rs
@@ -328,9 +328,9 @@ fn test_struct2() {
         # commentaire
       my = struct { # commentaire
           # ici un commentaire
-            a : 7;
             b : "salut"; # i am a comment
             c : [1,2,3];
+            a : 7;
       # autre : ["commentaire"];
             d : 1.;
             x : true;


### PR DESCRIPTION
Range definition:

```rust
for n in 1..10 {
    println(n)
}
```
Structs are now using comma + last comma not mandatory:

```C
x = struct {
     a: "hello",
     b: "world"
}
```